### PR TITLE
feat: Add Docker and Docker Compose for local development

### DIFF
--- a/McpServer/Dockerfile
+++ b/McpServer/Dockerfile
@@ -1,0 +1,18 @@
+#See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY ["McpServer/McpServer.csproj", "McpServer/"]
+COPY ["EmailReader/EmailReader.csproj", "EmailReader/"]
+RUN dotnet restore "McpServer/McpServer.csproj"
+COPY . .
+WORKDIR "/src/McpServer"
+RUN dotnet build "McpServer.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "McpServer.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "McpServer.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+services:
+  mcp-server:
+    build:
+      context: .
+      dockerfile: McpServer/Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - ASPNETCORE_URLS=http://+:8080
+      - Elasticsearch__Url=http://elasticsearch:9200
+    depends_on:
+      - elasticsearch
+    networks:
+      - mcp-net
+
+  elasticsearch:
+    image: elasticsearch:8.14.3
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    ports:
+      - "9200:9200"
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    networks:
+      - mcp-net
+
+volumes:
+  esdata:
+    driver: local
+
+networks:
+  mcp-net:
+    driver: bridge


### PR DESCRIPTION
This commit introduces a Dockerfile for the McpServer and a docker-compose.yml file to orchestrate the McpServer and an Elasticsearch container. This setup simplifies local development and testing by providing a consistent and reproducible environment.